### PR TITLE
feat: Modal Coponents 추가

### DIFF
--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -11,7 +11,7 @@ const Page = () => {
         openButtonContent="모달 열기"
         header={<ModalHeader title="타이틀" subTitle="서브타이틀" />}
         closeButtonContent="닫기"
-        footer={<ModalFooterWithAdditionalButton content="추가 버튼" />}>
+        additionalFooter={<ModalFooterWithAdditionalButton content="추가 버튼" />}>
         <div>
           <p>모달 테스트</p>
         </div>

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,9 +1,21 @@
 import List from '@/components/demo/List';
 import PrefetchHydration from '@/components/tanstackQuery/PrefetchHydration';
+import Modal from '@/components/Modal/Modal';
+import ModalHeader from '@/components/Modal/ModalHeader';
+import ModalFooterWithAdditionalButton from '@/components/Modal/ModalFooterWithAdditionalButton';
 
 const Page = () => {
   return (
     <div>
+      <Modal
+        openButtonContent="모달 열기"
+        header={<ModalHeader title="타이틀" subTitle="서브타이틀" />}
+        closeButtonContent="닫기"
+        footer={<ModalFooterWithAdditionalButton content="추가 버튼" />}>
+        <div>
+          <p>모달 테스트</p>
+        </div>
+      </Modal>
       {/* @ts-expect-error Server Component */}
       <PrefetchHydration
         queryKey={['demo']}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Button, ButtonProps, ModalBody, ModalFooter, ModalHeader } from '@chakra-ui/react';
+import { Modal as ModalWrapper, ModalOverlay, ModalContent, ModalCloseButton, useDisclosure } from '@chakra-ui/react';
+import { PropsWithChildren, ReactElement } from 'react';
+
+interface ModalProps {
+  size?: 'sm' | 'ml';
+  header?: ReactElement;
+  footer: ReactElement;
+  closeButtonContent: string;
+  closeButtonProps?: ButtonProps;
+  openButtonContent?: string;
+  openButtonProps?: ButtonProps;
+}
+
+const Modal = (props: PropsWithChildren<ModalProps>) => {
+  const {
+    size = 'ml',
+    header,
+    children,
+    footer,
+    closeButtonContent,
+    closeButtonProps,
+    openButtonContent,
+    openButtonProps,
+  } = props;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <Button onClick={onOpen} {...openButtonProps}>
+        {openButtonContent}
+      </Button>
+
+      <ModalWrapper isOpen={isOpen} onClose={onClose} size={size}>
+        <ModalOverlay />
+        <ModalContent alignItems="center">
+          <ModalHeader textAlign="center">{header}</ModalHeader>
+          <ModalBody>{children}</ModalBody>
+          <ModalFooter justifyContent="center" gap="2">
+            {closeButtonContent ? (
+              <Button onClick={onClose} {...closeButtonProps}>
+                {closeButtonContent}
+              </Button>
+            ) : (
+              ''
+            )}
+            {footer}
+          </ModalFooter>
+          <ModalCloseButton />
+        </ModalContent>
+      </ModalWrapper>
+    </>
+  );
+};
+
+export default Modal;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -8,7 +8,7 @@ interface ModalProps {
   size?: 'sm' | 'ml';
   header?: ReactElement;
   additionalFooter?: ReactElement;
-  closeButtonContent: string;
+  closeButtonContent?: string;
   closeButtonProps?: ButtonProps;
   openButtonContent?: string;
   openButtonProps?: ButtonProps;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,7 +5,7 @@ import { Modal as ModalWrapper, ModalOverlay, ModalContent, ModalCloseButton, us
 import { PropsWithChildren, ReactElement } from 'react';
 
 interface ModalProps {
-  size?: 'sm' | 'ml';
+  size?: 'sm' | 'md';
   header?: ReactElement;
   additionalFooter?: ReactElement;
   closeButtonContent?: string;
@@ -16,7 +16,7 @@ interface ModalProps {
 
 const Modal = (props: PropsWithChildren<ModalProps>) => {
   const {
-    size = 'ml',
+    size = 'md',
     header,
     children,
     additionalFooter,
@@ -33,7 +33,7 @@ const Modal = (props: PropsWithChildren<ModalProps>) => {
         {openButtonContent}
       </Button>
 
-      <ModalWrapper isOpen={isOpen} onClose={onClose} size={size}>
+      <ModalWrapper isOpen={isOpen} onClose={onClose} size={size} isCentered>
         <ModalOverlay />
         <ModalContent alignItems="center">
           <ModalHeader textAlign="center">{header}</ModalHeader>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import { PropsWithChildren, ReactElement } from 'react';
 interface ModalProps {
   size?: 'sm' | 'ml';
   header?: ReactElement;
-  footer: ReactElement;
+  additionalFooter?: ReactElement;
   closeButtonContent: string;
   closeButtonProps?: ButtonProps;
   openButtonContent?: string;
@@ -19,7 +19,7 @@ const Modal = (props: PropsWithChildren<ModalProps>) => {
     size = 'ml',
     header,
     children,
-    footer,
+    additionalFooter,
     closeButtonContent,
     closeButtonProps,
     openButtonContent,
@@ -46,7 +46,7 @@ const Modal = (props: PropsWithChildren<ModalProps>) => {
             ) : (
               ''
             )}
-            {footer}
+            {additionalFooter}
           </ModalFooter>
           <ModalCloseButton />
         </ModalContent>

--- a/src/components/Modal/ModalFooterWithAdditionalButton.tsx
+++ b/src/components/Modal/ModalFooterWithAdditionalButton.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button, ButtonProps } from '@chakra-ui/react';
+
+interface ModalFooter1ButtonProps {
+  content: string;
+  buttonProps?: ButtonProps;
+  onClick?: () => void;
+}
+// eslint-disable-next-line react/display-name
+const ModalFooterWithAdditionalButton = ({ content, buttonProps, onClick }: ModalFooter1ButtonProps) => (
+  <Button {...buttonProps} onClick={onClick}>
+    {content}
+  </Button>
+);
+
+export default ModalFooterWithAdditionalButton;

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -1,0 +1,13 @@
+interface ModalHeaderProps {
+  title: string;
+  subTitle?: string;
+}
+
+const ModalHeader = ({ title, subTitle }: ModalHeaderProps) => (
+  <>
+    <h2 className="text-2xl font-bold">{title}</h2>
+    {subTitle ? <p className="text-[1rem] font-normal">{subTitle}</p> : ''}
+  </>
+);
+
+export default ModalHeader;


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

1. 디자인 시스템을 기준으로 Chakra-ui 모달 컴포넌트를 활용하여 재사용성 높은 모달 컴포넌트를 작성하고자 했습니다.
2. Chakra-ui 컴포넌트를 사용하지 않는 부분은 tailwindCSS를 사용했습니다 - src/components/Modal/ModalHeader.tsx
3. 버튼 부분은 공통 컴포넌트 제작 완료 후 수정 예정입니다.

### 사용법
/demo 페이지에 테스트 모달을 작성했습니다.

구체적인 사용법입니다.

```jsx
<Modal
    openButtonContent="모달 열기"
    header={<ModalHeader title="타이틀" subTitle="서브타이틀" />}
    closeButtonContent="닫기"
    additionalFooter={<ModalFooterWithAdditionalButton content="추가 버튼" />}>
    /** Modal Body */    
    <div>
      <p>모달 테스트</p>
    </div>
</Modal>
```

- ModalContent 컴포넌트는 어느 컴포넌트든 들어 올 수 있기 때문에 children으로 받습니다.
- header, additionalFooter,  closeButtonContent props는 선택적으로 작성했습니다.

### 예시 화면

![image](https://github.com/depromeet/13th-4team-client/assets/85827017/3e5d51f8-db9d-4c5d-9ce5-5ff4de36bf19)
