### PR TITLE
feat: Input 컴포넌트

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "postcss": "8.4.23",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.43.9",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4",
     "zustand": "^4.3.8"
   },
   "devDependencies": {
+    "@hookform/devtools": "^4.3.1",
     "@storybook/addon-essentials": "^7.0.9",
     "@storybook/addon-interactions": "^7.0.9",
     "@storybook/addon-links": "^7.0.9",

--- a/src/app/demo/input/page.tsx
+++ b/src/app/demo/input/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import { DevTool as ReactHookFormDevTool } from '@hookform/devtools';
+
+import { Button, Stack, Text } from '@chakra-ui/react';
+import TextAreaField from '@/components/Input/TextAreaField/TextAreaField';
+import TextField from '@/components/Input/TextField/TextField';
+import TextLengthMessage from '@/components/Input/TextLengthMessage';
+
+type FormInputs = {
+  exampleTextArea: string;
+  exampleText: {
+    default: string;
+    naming: string;
+    password: string;
+    email: string;
+  };
+};
+
+export default function Demo() {
+  const { handleSubmit, control } = useForm<FormInputs>();
+
+  const submitHandler: SubmitHandler<FormInputs> = (data) => console.log(data);
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(submitHandler)}>
+        <Stack maxW={'3xl'} p={'10'}>
+          <Text fontSize="xl" as="b">
+            TextAreaField
+          </Text>
+          <Controller
+            name="exampleTextArea"
+            control={control}
+            rules={{ required: '답변을 작성해주세요!' }}
+            render={({ field: { ref, ...restField }, fieldState }) => (
+              <TextAreaField
+                withTextLengthMessage
+                placeholder="ex.개발자와 협업하기 위해 동아리에 들어감"
+                maxLength={100}
+                {...restField}
+                {...fieldState}
+              />
+            )}
+          />
+
+          <Text fontSize="xl" as="b">
+            TextField
+          </Text>
+          <Controller
+            name="exampleText.default"
+            control={control}
+            rules={{ required: '답변을 작성해주세요!' }}
+            render={({ field: { ref, ...restField }, fieldState }) => (
+              <TextField placeholder="ex.UI/UX 디자이너" {...restField} {...fieldState} />
+            )}
+          />
+          <Controller
+            name="exampleText.naming"
+            control={control}
+            rules={{ required: '답변을 작성해주세요!' }}
+            render={({ field: { ref, ...restField }, fieldState }) => (
+              <TextField
+                rightContent={<TextLengthMessage currentLength={restField.value?.length || 0} maxLength={5} />}
+                placeholder="닉네임"
+                {...restField}
+                {...fieldState}
+              />
+            )}
+          />
+          <Controller
+            name="exampleText.password"
+            control={control}
+            rules={{ required: '답변을 작성해주세요!' }}
+            render={({ field: { ref, ...restField }, fieldState }) => (
+              <TextField
+                type="password"
+                /** FIXME: 아이콘 컴포넌트 분리 필요 */
+                rightContent={
+                  <svg width="18" height="15" viewBox="0 0 18 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M17.0625 8.75H15.5625C15.45 8.75 15.375 8.675 15.375 8.5625C15.2625 5.3375 12.45 2.75 9 2.75C5.55 2.75 2.7375 5.3375 2.625 8.5625C2.625 8.675 2.55 8.75 2.4375 8.75H0.9375C0.825 8.75 0.75 8.675 0.75 8.5625C0.8625 4.2875 4.5 0.875 9 0.875C13.5 0.875 17.1375 4.2875 17.25 8.5625C17.25 8.675 17.175 8.75 17.0625 8.75Z"
+                      fill="#2B2D36"
+                    />
+                    <path
+                      d="M11.4 8.78748C11.625 9.27498 11.7 9.79998 11.5875 10.3625C11.4 11.4125 10.575 12.2375 9.56249 12.425C7.76249 12.8 6.18749 11.2625 6.41249 9.46248C6.56249 8.48748 7.23749 7.66248 8.17499 7.36248C8.66249 7.21248 9.11249 7.21248 9.56249 7.28748C9.67499 7.32498 9.74999 7.24998 9.78749 7.17498L10.2 5.74998C10.2375 5.63748 10.1625 5.52498 10.05 5.52498C9.41249 5.37498 8.69999 5.33748 7.94999 5.52498C6.14999 5.97498 4.72499 7.51248 4.53749 9.34998C4.19999 12.125 6.41249 14.4875 9.11249 14.4125C11.475 14.3375 13.4625 12.35 13.5 9.98748C13.5 9.23748 13.35 8.56248 13.05 7.92498C13.0125 7.81248 12.9 7.81248 12.7875 7.84998L11.475 8.56248C11.3625 8.59998 11.3625 8.71248 11.4 8.78748Z"
+                      fill="#2B2D36"
+                    />
+                  </svg>
+                }
+                placeholder="비밀번호를 입력하세요."
+                {...restField}
+                {...fieldState}
+              />
+            )}
+          />
+          <Controller
+            name="exampleText.email"
+            control={control}
+            rules={{ required: '답변을 작성해주세요!' }}
+            render={({ field: { ref, ...restField }, fieldState }) => (
+              <TextField rightContent={'@gmail.com'} placeholder="insightOut" {...restField} {...fieldState} />
+            )}
+          />
+          <Button type="submit">버튼을 눌러보세요 👀</Button>
+        </Stack>
+      </form>
+      <ReactHookFormDevTool control={control} placement="top-right" />
+    </>
+  );
+}

--- a/src/components/Input/@types/component.d.ts
+++ b/src/components/Input/@types/component.d.ts
@@ -1,0 +1,4 @@
+type Component<T extends React.ElementType> = {
+  className?: string;
+  children?: React.ReactNode;
+} & React.ComponentPropsWithRef<T>;

--- a/src/components/Input/TextAreaField/TextAreaField.tsx
+++ b/src/components/Input/TextAreaField/TextAreaField.tsx
@@ -1,0 +1,39 @@
+import { ControllerRenderProps, ControllerFieldState } from 'react-hook-form';
+
+import { FormControl, FormErrorMessage, Textarea } from '@chakra-ui/react';
+import TextLengthMessage from '../TextLengthMessage';
+
+type TextAreaFieldProps = Component<'textarea'> & {
+  withTextLengthMessage?: boolean;
+} & Omit<ControllerRenderProps, 'ref'> &
+  ControllerFieldState;
+
+/**
+ * 1. withTextLengthMessage에 따라 글자 수를 보여줍니다.
+ * 2. invalid하면 FormErrorMessage를 보여줍니다.
+ *
+ * @param withTextLenthMessage 글자 수를 보여줄지를 boolean으로 설정
+ * @param fieldState react-hook-form에서 입력에 대해 제공하는 값 (invalid, error, isDirty, isTouched)
+ */
+
+const TextAreaField = ({
+  withTextLengthMessage,
+  value,
+  error,
+  invalid,
+  isDirty,
+  isTouched,
+  ...textareaProps
+}: TextAreaFieldProps) => (
+  <FormControl isInvalid={invalid}>
+    <Textarea resize="none" {...textareaProps} />
+    <div>
+      <FormErrorMessage display={'inline-block'}>{error?.message}</FormErrorMessage>
+      {withTextLengthMessage && (
+        <TextLengthMessage currentLength={value?.length} maxLength={textareaProps?.maxLength || 0} />
+      )}
+    </div>
+  </FormControl>
+);
+
+export default TextAreaField;

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -1,0 +1,25 @@
+import { ControllerRenderProps, ControllerFieldState } from 'react-hook-form';
+
+import { FormControl, FormErrorMessage, Input, InputGroup, InputRightElement } from '@chakra-ui/react';
+
+type TextFieldProps = {
+  rightContent?: React.ReactNode;
+} & Omit<Component<'input'>, 'size'> &
+  Omit<ControllerRenderProps, 'ref'> &
+  ControllerFieldState;
+
+const TextField = ({ rightContent, error, invalid, isTouched, isDirty, ...inputProps }: TextFieldProps) => (
+  <FormControl isInvalid={invalid}>
+    <InputGroup>
+      <Input {...inputProps} />
+      {rightContent && (
+        <InputRightElement width="max" mr="4">
+          {rightContent}
+        </InputRightElement>
+      )}
+    </InputGroup>
+    {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
+  </FormControl>
+);
+
+export default TextField;

--- a/src/components/Input/TextLengthMessage.tsx
+++ b/src/components/Input/TextLengthMessage.tsx
@@ -1,0 +1,19 @@
+type TextLengthMessageProps = {
+  currentLength: number;
+  maxLength: number;
+};
+
+const TextLengthMessage = ({ currentLength, maxLength }: TextLengthMessageProps) => {
+  return (
+    <p className="float-right inline-block text-xs text-[#A1A3B0]">
+      <span>{formatCurrentTextLength(currentLength, maxLength)}</span>
+      <span>/{maxLength}</span>
+      <span>(공백포함)</span>
+    </p>
+  );
+};
+
+export default TextLengthMessage;
+
+const formatCurrentTextLength = (currentTextLength: number, maxTextLength: number) =>
+  String(currentTextLength || 0).padStart(String(maxTextLength || 0).length, '0');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,7 +1939,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
   integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
-"@emotion/react@^11.11.0":
+"@emotion/react@^11.1.5", "@emotion/react@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.0.tgz#408196b7ef8729d8ad08fc061b03b046d1460e02"
   integrity sha512-ZSK3ZJsNkwfjT3JpDAWJZlrGD81Z3ytNDsxw1LKq1o+xkmO5pnWfr6gmCC8gHEFf3nSSX/09YrG67jybNPxSUw==
@@ -1969,7 +1969,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
   integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
 
-"@emotion/styled@^11.11.0":
+"@emotion/styled@^11.11.0", "@emotion/styled@^11.3.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.11.0.tgz#26b75e1b5a1b7a629d7c0a8b708fbf5a9cdce346"
   integrity sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==
@@ -2152,6 +2152,20 @@
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
   integrity sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==
+
+"@hookform/devtools@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@hookform/devtools/-/devtools-4.3.1.tgz#5df1b77ea12b4f1c220da3d2dba737f81cbb12bc"
+  integrity sha512-CrWxEoHQZaOXJZVQ8KBgOuAa8p2LI8M0DAN5GTRTmdCieRwFVjVDEmuTAVazWVRRkpEQSgSt3KYp7VmmqXdEnw==
+  dependencies:
+    "@emotion/react" "^11.1.5"
+    "@emotion/styled" "^11.3.0"
+    "@types/lodash" "^4.14.168"
+    little-state-machine "^4.1.0"
+    lodash "^4.17.21"
+    react-simple-animate "^3.3.12"
+    use-deep-compare-effect "^1.8.1"
+    uuid "^8.3.2"
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
@@ -3735,7 +3749,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@^4.14.167":
+"@types/lodash@*", "@types/lodash@^4.14.167", "@types/lodash@^4.14.168":
   version "4.14.194"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
   integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
@@ -8105,6 +8119,11 @@ listr2@^5.0.7:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
+little-state-machine@^4.1.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/little-state-machine/-/little-state-machine-4.8.0.tgz#4853d01f71dc7e15fec00193692f845020a57686"
+  integrity sha512-xfi5+iDxTLhu0hbnNubUs+qoQQqxhtEZeObP5ELjUlHnl74bbasY7mOonsGQrAouyrbag3ebNLSse5xX1T7buQ==
+
 loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
@@ -9335,6 +9354,11 @@ react-focus-lock@^2.9.2:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-hook-form@^7.43.9:
+  version "7.43.9"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.9.tgz#84b56ac2f38f8e946c6032ccb760e13a1037c66d"
+  integrity sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==
+
 react-inspector@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.1.tgz#1a37f0165d9df81ee804d63259eaaeabe841287d"
@@ -9383,6 +9407,11 @@ react-remove-scroll@^2.5.5:
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
+
+react-simple-animate@^3.3.12:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/react-simple-animate/-/react-simple-animate-3.5.2.tgz#ab08865c8bd47872b92bd1e25902326bf7c695b3"
+  integrity sha512-xLE65euP920QMTOmv5haPlml+hmOPDkbIr5WeF7ADIXWBYt5kW/vwpNfWg8EKMab8aeDxIZ6QjffVh8v2dUyhg==
 
 react-style-singleton@^2.2.1:
   version "2.2.1"
@@ -10781,6 +10810,14 @@ use-callback-ref@^1.3.0:
   dependencies:
     tslib "^2.0.0"
 
+use-deep-compare-effect@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
+  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    dequal "^2.0.2"
+
 use-resize-observer@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-9.1.0.tgz#14735235cf3268569c1ea468f8a90c5789fc5c6c"
@@ -10826,6 +10863,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 uuid@^9.0.0:
   version "9.0.0"


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#11

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
1. react-hook-form / devtool 설치
2. chakra를 이용해서 TextField, TextAreaField 구현 (네이밍은 피그마 참고)
3. `TextLengthMessage.tsx`: 사용자가 입력한 글자 수 / 최대 입력 가능 글자 수` 를 보여주는 컴포넌트 구현

### 사용법
- `/demo/input` 페이지에서 사용 예시를 볼 수 있습니다.
- 자세한 내용은 [react-hook-form에 관련해서 정리한 내용](https://www.notion.so/depromeet/react-hook-form-68018d7244c041aa9313892416767523?pvs=4)을 참고해주세요. (여기에 쓰면 팔만대장경됨..)

#### TextAreaField
``` tsx
<TextAreaField
  withTextLengthMessage
  placeholder="ex.개발자와 협업하기 위해 동아리에 들어감"
  maxLength={100}
  {...field}
  {...fieldState}
/>
```
- `withTextLengthMessage`: 글자수 세기가 있는 경우
- native textarea props는 모두 가능

#### TextField
``` tsx
<TextField rightContent={'@gmail.com'} placeholder="insightOut" {...field} {...fieldState} />
```
- `rightContent`: 입력창 오른쪽에 표시되는 컴포넌트 (예: 아이콘)
- native input props는 모두 가능

#### react-hook-form의 Controller와 함께 사용하기
``` tsx
<Controller
  name="input의 키"
  control={control} /* useForm의 반환 값: form의 상태와 제어할 수 있음 */
  rules={{ required: '답변을 작성해주세요!' }} /* 유효성 검사 */
  render={({ field: { ref, ...restField }, fieldState }) => ( /* 렌더링할 input 컴포넌트 */
    <TextField placeholder="ex.UI/UX 디자이너" {...restField} {...fieldState} />
  )}
/>
```

### 예시 화면
![image](https://github.com/depromeet/13th-4team-client/assets/80238096/8c3875bc-3485-4eaa-89eb-58fdd6674622)


### Todo
- [ ] 디자인 토큰에 따라 chakra 컴포넌트 스타일 변경
- [ ] 아이콘 컴포넌트 분리
- [ ] 스토리북 설정
   - 스토리북으로 공유하면 편할 것 같아서 관련 설정 이미 해놓긴 했는데 PR 분리해서 올리도록 하겠습니다~!

---

여러분들의 의견이 적극 필요합니다 .. 🧎‍♀️

react-hook-form을 잘못 공부한건지.. 주절주절 설명이 많아지는게 이해하기 어려운 컴포넌트로 보입니다 .. 

새로 짤 생각 있으니까 가감없이 솔직헌 의견 궁금합니다 (솔직히 저는 마음에 안듭니다..🗿: 사용하기 어려움 +  가독성 구림)