### PR TITLE
feat: Input 컴포넌트 (compound 컴포넌트로 구현)

### DIFF
--- a/src/app/demo/input/page.tsx
+++ b/src/app/demo/input/page.tsx
@@ -1,0 +1,34 @@
+import { Input } from '@/components/Input/Input';
+
+const Page = () => {
+  return (
+    <>
+      <div className="flex flex-col gap-4 p-10">
+        <Input.TextField placeholder="abc@gmail.com" />
+        <Input.TextField disabled placeholder="abc@gmail.com" />
+        <Input>
+          <Input.TextField placeholder="abc@gmail.com" />
+          <Input.RightContent>
+            <Input.TextLengthMessage currentLength={0} maxLength={100} />
+          </Input.RightContent>
+        </Input>
+        <Input>
+          <Input.TextField placeholder="abc@gmail.com" />
+          <Input.RightContent>@gmail.com</Input.RightContent>
+        </Input>
+      </div>
+
+      <div className="flex flex-col gap-4 p-10">
+        <Input.TextareaField placeholder="abc@gmail.com" />
+        <Input.TextareaField disabled placeholder="abc@gmail.com" />
+        <Input.TextareaField error placeholder="abc@gmail.com" />
+        <Input.ErrorMessage>필수 입력사항입니다.</Input.ErrorMessage>
+
+        <Input.TextareaField />
+        <Input.TextLengthMessage currentLength={0} maxLength={100} />
+      </div>
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,4 +113,17 @@
     line-height: 14px;
     letter-spacing: -0.6px;
   }
+
+  /* form에 해당하는 모든 컴포넌트: select, input */
+  .form {
+    @apply p-4 b2 text-gray-300 bg-white border-[1px] rounded-2xl border-gray-300 hover:text-gray-500 hover:border-gray-500 focus:text-main focus:border-gray-600 disabled:text-gray-500 disabled:bg-gray-100 disabled:border-gray-200 focus-visible:outline-none;
+  }
+
+  .form-typed {
+    @apply border-purple-200 form text-main bg-purple-50;
+  }
+
+  .form-error {
+    @apply form border-error;
+  }
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,68 @@
+import { ComponentPropsWithRef, PropsWithChildren } from 'react';
+
+type InputProps = ComponentPropsWithRef<'input'> & {
+  isTyped?: boolean;
+  error?: boolean;
+};
+
+type TextareaProps = ComponentPropsWithRef<'textarea'> & {
+  isTyped?: boolean;
+  error?: boolean;
+};
+
+type InputRightContentProps = PropsWithChildren & { children: React.ReactNode };
+
+type TextLengthMessageProps = {
+  className?: string;
+  currentLength: number;
+  maxLength: number;
+};
+
+const InputContainer = ({ children }: PropsWithChildren & { error?: boolean }) => {
+  return <div className="relative">{children}</div>;
+};
+
+const TextField = ({ isTyped, error, ...props }: InputProps) => {
+  return <input className={`form w-full ${isTyped ? 'form-typed' : ''} ${error ? 'form-error' : ''}`} {...props} />;
+};
+
+const TextareaField = ({ isTyped, error, ...props }: TextareaProps) => {
+  return (
+    <textarea {...props} className={`form resize-none ${isTyped ? 'form-typed' : ''} ${error ? 'form-error' : ''}`} />
+  );
+};
+
+const RightContent = ({ children }: InputRightContentProps) => {
+  return <div className="absolute -translate-y-1/2 right-4 top-1/2">{children}</div>;
+};
+
+const ErrorMessage = ({ children }: PropsWithChildren) => {
+  return (
+    <p role="alert" className="my-2 text-xs text-error">
+      {children}
+    </p>
+  );
+};
+
+const TextLengthMessage = ({ className, currentLength, maxLength }: TextLengthMessageProps) => {
+  return (
+    <p className={`text-gray-500 c1 ${className}`}>
+      <span className={currentLength > 0 ? 'text-green-400' : ''}>
+        {formatCurrentTextLength(currentLength, maxLength)}
+      </span>
+      <span>/{maxLength}</span>
+    </p>
+  );
+};
+
+export const Input = Object.assign(InputContainer, {
+  TextField,
+  TextareaField,
+  ErrorMessage,
+  RightContent,
+  TextLengthMessage,
+});
+
+/** util */
+const formatCurrentTextLength = (currentTextLength: number, maxTextLength: number) =>
+  String(currentTextLength || 0).padStart(String(maxTextLength || 0).length, '0');


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#11

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

- #14 내용과 다른 부분만 적도록 하겠습니다~

#### Input 컴포넌트 구현 방식

- compound 컴포넌트로 구현하였습니다.
- 장점: 유연성, 확장 가능성
- 단점
   - 사용부에서 조립해서 사용해야하기 때문에 사용성이 떨어질 수 있음
   - Input 컴포넌트가 유연하고 확장해야할 필요가 없을 수 있음 

### 사용 방법

#### TextField

- 기본 사용
``` tsx
<Input.TextField placeholder="abc@gmail.com" />
```

- 오른쪽에 컨텐츠가 있는 경우
``` tsx
<Input>
  <Input.TextField placeholder="abc@gmail.com" />
  <Input.RightContent>
    /* Input의 오른쪽에 위치하는 컴포넌트로 어떤 컴포넌트든 들어올 수 있습니다. */
    <Input.TextLengthMessage currentLength={0} maxLength={100} />
  </Input.RightContent>
</Input>
```

#### TextareField

-  기본 사용
``` tsx
<Input.TextareaField placeholder="abc@gmail.com" />
```

- 에러가 있는 경우
``` tsx
<Input.TextareaField error placeholder="abc@gmail.com" />
<Input.ErrorMessage>필수 입력사항입니다.</Input.ErrorMessage>
```

- 글자수가 있는 경우
``` tsx
<Input.TextareaField />
<Input.TextLengthMessage currentLength={0} maxLength={100} />
```