### PR TITLE
feat: Tag 컴포넌트 variant 추가

### DIFF
--- a/src/components/Tag/Tag.module.scss
+++ b/src/components/Tag/Tag.module.scss
@@ -12,7 +12,7 @@
 }
 
 .primary-outline {
-  @apply bg-primary-50 text-primary-500 border-primary-300;
+  @apply bg-primary-50 text-primary-500 border border-primary-300;
 }
 
 .secondary {
@@ -20,7 +20,7 @@
 }
 
 .secondary-outline {
-  @apply bg-secondary-50 text-secondary-700 border-secondary-300;
+  @apply bg-secondary-50 text-secondary-700 border border-secondary-300;
 }
 
 .tertiary {

--- a/src/components/Tag/Tag.module.scss
+++ b/src/components/Tag/Tag.module.scss
@@ -3,19 +3,31 @@
 }
 
 // Variant
-.primary {
+.primary-50 {
   @apply bg-primary-50 text-primary-400;
 }
 
-.secondary {
+.primary-500 {
   @apply bg-primary-500 text-white;
+}
+
+.primary-outline {
+  @apply bg-primary-50 text-primary-500 border-primary-300;
+}
+
+.secondary {
+  @apply bg-secondary-500 text-white;
+}
+
+.secondary-outline {
+  @apply bg-secondary-50 text-secondary-700 border-secondary-300;
 }
 
 .tertiary {
   @apply bg-gray-100 text-gray-700;
 }
 
-.darkmode {
+.gray-800 {
   @apply bg-gray-800 text-white;
 }
 

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -41,13 +41,13 @@ export const Default: Story = {
         </div>
         <h3>Primay-outline</h3>
         <div className="flex gap-6 ">
-          <Tag variant="primary-500" size="s1">
+          <Tag variant="primary-outline" size="s1">
             여기에키워드를써요
           </Tag>
-          <Tag variant="primary-500" size="s2">
+          <Tag variant="primary-outline" size="s2">
             여기에키워드를써요
           </Tag>
-          <Tag variant="primary-500" size="s3">
+          <Tag variant="primary-outline" size="s3">
             여기에키워드를써요
           </Tag>
         </div>

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -15,27 +15,39 @@ export const Default: Story = {
   render: () => {
     return (
       <div className="flex flex-col gap-4">
-        <h3>Tertiary</h3>
+        <h3>Primay-50</h3>
         <div className="flex gap-6 ">
-          <Tag variant="tertiary" size="s1">
+          <Tag variant="primary-50" size="s1">
             여기에키워드를써요
           </Tag>
-          <Tag variant="tertiary" size="s2">
+          <Tag variant="primary-50" size="s2">
             여기에키워드를써요
           </Tag>
-          <Tag variant="tertiary" size="s3">
+          <Tag variant="primary-50" size="s3">
             여기에키워드를써요
           </Tag>
         </div>
-        <h3>Primay</h3>
+        <h3>Primay-500</h3>
         <div className="flex gap-6 ">
-          <Tag variant="primary" size="s1">
+          <Tag variant="primary-500" size="s1">
             여기에키워드를써요
           </Tag>
-          <Tag variant="primary" size="s2">
+          <Tag variant="primary-500" size="s2">
             여기에키워드를써요
           </Tag>
-          <Tag variant="primary" size="s3">
+          <Tag variant="primary-500" size="s3">
+            여기에키워드를써요
+          </Tag>
+        </div>
+        <h3>Primay-outline</h3>
+        <div className="flex gap-6 ">
+          <Tag variant="primary-500" size="s1">
+            여기에키워드를써요
+          </Tag>
+          <Tag variant="primary-500" size="s2">
+            여기에키워드를써요
+          </Tag>
+          <Tag variant="primary-500" size="s3">
             여기에키워드를써요
           </Tag>
         </div>
@@ -51,15 +63,39 @@ export const Default: Story = {
             여기에키워드를써요
           </Tag>
         </div>
-        <h3>Darkmode</h3>
+        <h3>Secondary-outline</h3>
         <div className="flex gap-6 ">
-          <Tag variant="darkmode" size="s1">
+          <Tag variant="secondary-outline" size="s1">
             여기에키워드를써요
           </Tag>
-          <Tag variant="darkmode" size="s2">
+          <Tag variant="secondary-outline" size="s2">
             여기에키워드를써요
           </Tag>
-          <Tag variant="darkmode" size="s3">
+          <Tag variant="secondary-outline" size="s3">
+            여기에키워드를써요
+          </Tag>
+        </div>
+        <h3>Tertiary</h3>
+        <div className="flex gap-6 ">
+          <Tag variant="tertiary" size="s1">
+            여기에키워드를써요
+          </Tag>
+          <Tag variant="tertiary" size="s2">
+            여기에키워드를써요
+          </Tag>
+          <Tag variant="tertiary" size="s3">
+            여기에키워드를써요
+          </Tag>
+        </div>
+        <h3>Gray-800</h3>
+        <div className="flex gap-6 ">
+          <Tag variant="gray-800" size="s1">
+            여기에키워드를써요
+          </Tag>
+          <Tag variant="gray-800" size="s2">
+            여기에키워드를써요
+          </Tag>
+          <Tag variant="gray-800" size="s3">
             여기에키워드를써요
           </Tag>
         </div>

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -8,7 +8,7 @@ interface TagProps extends Omit<ComponentProps<'span'>, 'children'> {
   children: string;
 }
 
-const Tag = ({ variant = 'primary', size, children, className, ...props }: TagProps) => {
+const Tag = ({ variant = 'primary-50', size, children, className, ...props }: TagProps) => {
   const rootClassName = cn(styles.root, styles[variant], styles[size], className);
 
   return (

--- a/src/services/@types/component.d.ts
+++ b/src/services/@types/component.d.ts
@@ -10,6 +10,9 @@ type MergeComponentProps<T extends React.ElementType, P extends object = {}> = O
 > &
   P;
 
+// color scale
+type colorScale = 50 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+
 // Button
 
 type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'secondary-secondary' | 'outlined';
@@ -34,3 +37,14 @@ type BadgeSize = 'sm' | 'md' | 'lg';
 // Tab
 
 type TabSize = 'xs' | 'sm' | 'md' | 'lg';
+
+// Tag
+type TagVariant =
+  | 'primary-50'
+  | 'primary-500'
+  | 'primary-outline'
+  | 'secondary'
+  | 'secondary-outline'
+  | 'tertiary'
+  | 'gray-800';
+type TagSize = 's1' | 's2' | 's3';

--- a/src/services/@types/tag.d.ts
+++ b/src/services/@types/tag.d.ts
@@ -1,4 +1,0 @@
-/* eslint-disable unused-imports/no-unused-vars */
-
-type TagVariant = 'primary' | 'secondary' | 'tertiary' | 'darkmode';
-type TagSize = 's1' | 's2' | 's3';


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#54

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용

[Tag 컴포넌트](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=452-3399&t=Hoo28XiaJO9SlY7O-0) 스타일 추가되어 수정 했습니다.

purple 계열은 primary로 작업 했습니다.
cyon 계열은 secondary로 작업 했습니다.
디자인시스템 color명과 통일성이 있는 네이밍을 사용했습니다.