### PR TITLE
fix: Link href type 에러로 build 실패 해결

### DIFF
--- a/src/app/resume/[id]/page.tsx
+++ b/src/app/resume/[id]/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const page = () => {
+  return <div>page</div>;
+};
+
+export default page;

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -2,11 +2,12 @@ import React, { ReactElement } from 'react';
 import cn from 'classnames';
 import styles from './Tab.module.scss';
 import Link from 'next/link';
+import { UrlObject } from 'url';
 
 type TabProps = MergeComponentProps<
   'a',
   {
-    href: Url;
+    href: UrlObject | __next_route_internal_types__.RouteImpl<string>;
     /** @description 탭 크기 (xs, sm, md, lg) */
     size: TabSize;
     /** @description Badge 컴포넌트 */

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -2,12 +2,12 @@ import React, { ReactElement } from 'react';
 import cn from 'classnames';
 import styles from './Tab.module.scss';
 import Link from 'next/link';
-import { UrlObject } from 'url';
+import { LinkHref } from '@/shared/@types/route';
 
 type TabProps = MergeComponentProps<
   'a',
   {
-    href: UrlObject | __next_route_internal_types__.RouteImpl<string>;
+    href: LinkHref;
     /** @description 탭 크기 (xs, sm, md, lg) */
     size: TabSize;
     /** @description Badge 컴포넌트 */

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement } from 'react';
 import cn from 'classnames';
 import styles from './Tab.module.scss';
 import Link from 'next/link';
-import { LinkHref } from '@/shared/@types/route';
 
 type TabProps = MergeComponentProps<
   'a',

--- a/src/shared/@types/route.d.ts
+++ b/src/shared/@types/route.d.ts
@@ -1,0 +1,3 @@
+/* eslint-disable unused-imports/no-unused-vars */
+
+type LinkHref = UrlObject | __next_route_internal_types__.RouteImpl<string>;


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
Link href type 에러로 build 실패 해결
- Tag href type 수정
- /resume/${id} 페이지 임시 추가