### PR TITLE
feat: 자기소개서 - 첫 진입 화면 온보딩

### DIFF
--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import GlobalNavigationBar from '@/components/GlobalNavigationBar/GlobalNavigationBar';
+import OnboardingProvider from '@/components/Providers/OnboardingProvider';
 import AuthProvider from '@/features/auth/components/Providers/AuthProvider';
 import { useIsRequesting, useIsSignedIn } from '@/features/auth/store';
 
@@ -11,7 +12,7 @@ export default function Template({ children }: StrictPropsWithChildren) {
   return (
     <AuthProvider>
       <GlobalNavigationBar isSignedIn={isSignedIn} isRequesting={isRequesting} />
-      {children}
+      <OnboardingProvider>{children}</OnboardingProvider>
     </AuthProvider>
   );
 }

--- a/src/components/Providers/OnboardingProvider.tsx
+++ b/src/components/Providers/OnboardingProvider.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import onboardingApi from '@/apis/onboarding/onboarding';
+import { useIsSignedIn } from '@/features/auth/store';
+import { ROUTES } from '@/shared/constants/routes';
+import { useUserActions } from '@/shared/store/user';
+
+/**
+ * 페이지 마운트 시, 온보딩을 조회하는 Provider
+ * - 페이지를 새로 마운트하는 경우, 로그인 시 응답 받은 온보딩 값이 없습니다.
+ *
+ * - 로그인 여부와 온보딩을 사용하는 페이지인지 확인합니다.
+ * - 로그인 상태에서 현재 페이지가 온보딩을 사용하는 경우, 아래 로직이 실행됩니다.
+ *    - 1. 서버에 온보딩을 조회합니다.
+ *    - 2. 서버로부터 응답 받은 온보딩 값을 userStore에 저장합니다.
+ */
+export default function OnboardingProvider({ children }: StrictPropsWithChildren) {
+  const pathname = usePathname();
+  const isSignedIn = useIsSignedIn();
+  const { setUserInfo } = useUserActions();
+
+  const onboardingPages = [ROUTES.EXPERIENCE, ROUTES.RESUMES];
+
+  useEffect(() => {
+    if (!isSignedIn || !onboardingPages.some((onboardingPage) => pathname.startsWith(onboardingPage))) return;
+
+    (async () => {
+      try {
+        const onboarding = await onboardingApi.get();
+        setUserInfo({ onboarding });
+      } catch (error) {
+        // FIXME: 에러 처리
+        console.error(error);
+      }
+    })();
+  });
+
+  return <>{children}</>;
+}

--- a/src/components/Providers/OnboardingProvider.tsx
+++ b/src/components/Providers/OnboardingProvider.tsx
@@ -19,14 +19,14 @@ import { useUserActions } from '@/shared/store/user';
  *    - 2. 서버로부터 응답 받은 온보딩 값을 userStore에 저장합니다.
  */
 export default function OnboardingProvider({ children }: StrictPropsWithChildren) {
-  const pathname = usePathname();
+  const currentPath = usePathname();
   const isSignedIn = useIsSignedIn();
   const { setUserInfo } = useUserActions();
 
   const onboardingPages = [ROUTES.EXPERIENCE, ROUTES.RESUMES];
 
   useEffect(() => {
-    if (!isSignedIn || !onboardingPages.some((onboardingPage) => pathname.startsWith(onboardingPage))) return;
+    if (!isSignedIn || !onboardingPages.some((onboardingPage) => currentPath.startsWith(onboardingPage))) return;
 
     (async () => {
       try {
@@ -37,7 +37,7 @@ export default function OnboardingProvider({ children }: StrictPropsWithChildren
         console.error(error);
       }
     })();
-  });
+  }, [isSignedIn, currentPath]);
 
   return <>{children}</>;
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -17,19 +17,23 @@ type TooltipProps = MergeComponentProps<
     content: string;
     /** @description 출력된 채로 고정 여부 */
     alwaysOpen?: boolean;
+    /**
+     * @description 툴팁 추가 간격
+     * - 기본 간격 17px (툴팁의 기본 간격 8px + 툴팁 Arrow 크기 9px = 17px) */
+    offset?: number;
   }
 >;
 
 /**
  * @name 툴팁컴포넌트
  */
-const Tooltip = ({ type, position, content, children, alwaysOpen }: TooltipProps) => {
+const Tooltip = ({ type, position, content, children, alwaysOpen, offset }: TooltipProps) => {
   const childrenRef = useRef<HTMLDivElement>(null);
 
   const [isOpen, setIsOpen] = useState(false);
   const [childrenRect, setChildrenRect] = useState<DOMRect>();
 
-  const tooltipPlacement = getPlacement(position, OFFSET, childrenRect);
+  const tooltipPlacement = getPlacement(position, OFFSET + (offset ?? 0), childrenRect);
 
   useEffect(() => {
     const childrenElement = childrenRef.current;

--- a/src/features/resume/components/Aside/Aside.tsx
+++ b/src/features/resume/components/Aside/Aside.tsx
@@ -43,7 +43,8 @@ const Aside = () => {
             position="left-bottom"
             content="‘자기소개서 추가' 버튼을 눌러 작성을 시작해보세요!"
             alwaysOpen
-            className="b1">
+            className="b1"
+            offset={14}>
             <Button variant="primary" size="M" onClick={handleAddFolderButtonClick}>
               자기소개서 추가
             </Button>

--- a/src/features/resume/components/Aside/Aside.tsx
+++ b/src/features/resume/components/Aside/Aside.tsx
@@ -3,21 +3,27 @@
 import Button from '@/components/Button/Button';
 import IconPencil from '@/components/Icon/IconPencil';
 import Tooltip from '@/components/Tooltip/Tooltip';
+import { useUpdateOnboarding } from '@/hooks/reactQuery/onboarding/mutation';
 import { useCreateResume } from '@/hooks/reactQuery/resume/mutation';
 import { useGetResumes } from '@/hooks/reactQuery/resume/query';
-import { useUserOnboarding } from '@/shared/store/user';
+import { useUserActions, useUserOnboarding } from '@/shared/store/user';
 
 import Resume from './Resume/Resume';
 import ResumeListContainer from './Resume/ResumeListContainer';
 
 const Aside = () => {
-  const { resume: isResumeOnboardingComplete } = useUserOnboarding();
+  const { resume: isResumeOnboardingComplete, ...restOnboardings } = useUserOnboarding();
+  const { setUserInfo } = useUserActions();
 
   const { mutate: createResume } = useCreateResume();
   const { data: resumeList } = useGetResumes();
+  const { mutate: updateResumeOnboarding } = useUpdateOnboarding({
+    onSuccess: () => setUserInfo({ onboarding: { ...restOnboardings, resume: true } }),
+  });
 
   const handleAddFolderButtonClick = () => {
     createResume();
+    if (!isResumeOnboardingComplete) updateResumeOnboarding({ resume: true });
   };
 
   return (

--- a/src/features/resume/components/Aside/Aside.tsx
+++ b/src/features/resume/components/Aside/Aside.tsx
@@ -2,13 +2,17 @@
 
 import Button from '@/components/Button/Button';
 import IconPencil from '@/components/Icon/IconPencil';
+import Tooltip from '@/components/Tooltip/Tooltip';
 import { useCreateResume } from '@/hooks/reactQuery/resume/mutation';
 import { useGetResumes } from '@/hooks/reactQuery/resume/query';
+import { useUserOnboarding } from '@/shared/store/user';
 
 import Resume from './Resume/Resume';
 import ResumeListContainer from './Resume/ResumeListContainer';
 
 const Aside = () => {
+  const { resume: isResumeOnboardingComplete } = useUserOnboarding();
+
   const { mutate: createResume } = useCreateResume();
   const { data: resumeList } = useGetResumes();
 
@@ -23,9 +27,22 @@ const Aside = () => {
           <IconPencil />
           <span>내 자기소개서</span>
         </h1>
-        <Button variant="primary" size="M" onClick={handleAddFolderButtonClick}>
-          자기소개서 추가
-        </Button>
+        {isResumeOnboardingComplete ? (
+          <Button variant="primary" size="M" onClick={handleAddFolderButtonClick}>
+            자기소개서 추가
+          </Button>
+        ) : (
+          <Tooltip
+            type="strong"
+            position="left-bottom"
+            content="‘자기소개서 추가' 버튼을 눌러 작성을 시작해보세요!"
+            alwaysOpen
+            className="b1">
+            <Button variant="primary" size="M" onClick={handleAddFolderButtonClick}>
+              자기소개서 추가
+            </Button>
+          </Tooltip>
+        )}
       </header>
       <ResumeListContainer expandedResumeCount={resumeList?.length}>
         {resumeList?.map((resume) => (

--- a/src/hooks/reactQuery/onboarding/mutation.ts
+++ b/src/hooks/reactQuery/onboarding/mutation.ts
@@ -1,0 +1,13 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import onboardingApi from '@/apis/onboarding/onboarding';
+import { OnboardingInfo } from '@/shared/store/types/user';
+
+export const useUpdateOnboarding = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, Partial<OnboardingInfo>>
+) => {
+  return useMutation((param) => onboardingApi.patch(param), {
+    ...options,
+  });
+};

--- a/src/shared/store/user.ts
+++ b/src/shared/store/user.ts
@@ -10,7 +10,7 @@ export const userStore = create<UserState>((set) => ({
       field: false,
       experience: false,
       experienceStepper: false,
-      resume: false,
+      resume: true,
       collection: false,
     },
     email: '',


### PR DESCRIPTION
### 이슈 번호

close depromeet/13th-4team-client#98

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

### 1. 온보딩 툴팁
![스크린샷 2023-07-04 오후 11 04 28](https://github.com/depromeet/InsightOut-client/assets/80238096/2c2680cd-9fbd-40b2-a20a-bced9dc561f0)

1. 툴팁 표시
- userStore에 있는 온보딩 값을 이용
- 온보딩을 하지 않았을 경우 툴팁 표시

2. 자기소개서 추가 버튼 클릭시 
- 온보딩 완료로 업데이트

### 2. `OnboardingProvider`

- 페이지를 새로 마운트하는 경우, 로그인 시 응답 받은 온보딩 값이 없고 초기값으로 존재합니다.
-> OnboardingProvider로 감싸서 페이지 마운트 시, 서버에 온보딩 값을 요청합니다.

- 로그인을 한 사용자가 + 온보딩 값이 필요한 페이지에 접근했을 시에만 서버에 온보딩 값을 요청합니다.

### 3. `Tooltip` 컴포넌트에 `offset` props 추가

- 툴팁 위치 조정이 안돼서 offset props를 추가했습니다.
- 기존 `OFFSET (17px)`에 추가적으로 offset props 값을 더해서 툴팁 위치를 조정합니다.