### PR TITLE
feat: 경험카드 모아보기 - 무한스크롤 적용

### DIFF
--- a/src/apis/experience/types/experience.ts
+++ b/src/apis/experience/types/experience.ts
@@ -5,6 +5,7 @@ export type ExperienceParams = {
   get: {
     id?: string;
     last?: boolean;
+    page?: number;
     capabilityId?: number;
     situation?: boolean;
     task?: boolean;

--- a/src/app/collection/experiences/page.tsx
+++ b/src/app/collection/experiences/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import TextButton from '@/components/Button/TextButton';
 import IconClock from '@/components/Icon/IconClock';
@@ -11,14 +11,32 @@ import { Capability, Experience } from '@/features/collection/types';
 import getAllCapability from '@/features/collection/utils/getAllCapabilityBadgeItem';
 import getFilteredExperiences from '@/features/collection/utils/getFilteredExperiences';
 import getSortedExperiences from '@/features/collection/utils/getSortedExperiences';
-import { useGetExperienceCapabilities, useGetExperiences } from '@/hooks/reactQuery/experience/qeury';
+import {
+  useGetExperienceCapabilities,
+  // useGetExperiences,
+  useGetInfiniteExperiences,
+} from '@/hooks/reactQuery/experience/qeury';
+import useIntersection from '@/hooks/useIntersection';
 
 const Page = () => {
   const { data: capabilities } = useGetExperienceCapabilities();
 
   const _capabilites = capabilities || [];
 
-  const { data: experiences } = useGetExperiences();
+  /**
+   * 무한스크롤 적용을 위해 주석처리했습니다.
+   * - 무한스크롤 관련 코드: 32 ~ 39줄
+   */
+  // const { data: experiences } = useGetExperiences();
+
+  const { data, fetchNextPage, hasNextPage, isFetching } = useGetInfiniteExperiences();
+  const experiences = useMemo(() => (data ? data.pages.flatMap(({ data }) => data) : []), [data]);
+
+  const ref = useIntersection((entry, observer) => {
+    observer.unobserve(entry.target);
+
+    if (hasNextPage && !isFetching) fetchNextPage();
+  });
 
   // TODO: notFound 처리
   // if (!experiences) notFound();
@@ -35,12 +53,12 @@ const Page = () => {
   };
 
   // TODO: 백엔드와 경험 시간 값을 논의 refactor
-  let __experiences = experiences?.data || [];
-  if (experiences?.data) {
+  let __experiences = experiences || [];
+  if (experiences) {
     const _experiences =
       selectedCapabilitykeyword === allCapability.keyword
-        ? experiences?.data ?? []
-        : getFilteredExperiences(experiences?.data ?? [], selectedCapabilitykeyword);
+        ? experiences ?? []
+        : getFilteredExperiences(experiences ?? [], selectedCapabilitykeyword);
 
     __experiences = getSortedExperiences(_experiences, sortBy);
   }
@@ -66,6 +84,7 @@ const Page = () => {
               <ExperienceListCard {...experience} />
             </li>
           ))}
+          <div ref={ref}></div>
         </ul>
       </section>
     </>

--- a/src/hooks/reactQuery/experience/qeury.ts
+++ b/src/hooks/reactQuery/experience/qeury.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useInfiniteQuery, UseInfiniteQueryOptions, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { EXPERIENCE_API, EXPERIENCE_CAPABILITY_API, EXPERIENCE_COUNT_API } from '@/apis/experience/experience';
@@ -23,12 +23,16 @@ export const useGetExperiences = (
     }
   );
 
-export const useGetInfiniteExperiences = (params?: ExperienceParams['get']) =>
+export const useGetInfiniteExperiences = (
+  params?: ExperienceParams['get'],
+  options?: UseInfiniteQueryOptions<ExperiencesResponse, AxiosError>
+) =>
   useInfiniteQuery<ExperiencesResponse, AxiosError>(
     EXPERIENCE_KEY.list([{ ...params }]),
     ({ pageParam = 1 }) => EXPERIENCE_API.get({ ...params, page: pageParam }),
     {
       getNextPageParam: ({ meta: { hasNextPage, page } }) => (hasNextPage ? page + 1 : undefined),
+      ...options,
     }
   );
 

--- a/src/hooks/reactQuery/experience/qeury.ts
+++ b/src/hooks/reactQuery/experience/qeury.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { EXPERIENCE_API, EXPERIENCE_CAPABILITY_API, EXPERIENCE_COUNT_API } from '@/apis/experience/experience';
@@ -20,6 +20,15 @@ export const useGetExperiences = (
     () => EXPERIENCE_API.get({ ...params }),
     {
       ...options,
+    }
+  );
+
+export const useGetInfiniteExperiences = (params?: ExperienceParams['get']) =>
+  useInfiniteQuery<ExperiencesResponse, AxiosError>(
+    EXPERIENCE_KEY.list([{ ...params }]),
+    ({ pageParam = 1 }) => EXPERIENCE_API.get({ ...params, page: pageParam }),
+    {
+      getNextPageParam: ({ meta: { hasNextPage, page } }) => (hasNextPage ? page + 1 : undefined),
     }
   );
 

--- a/src/hooks/useIntersection.ts
+++ b/src/hooks/useIntersection.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Intersection Observer API를 사용하는 훅입니다.
+ * - target으로 설정한 요소와 뷰포트와 교차하는지 구별합니다.
+ * - 무한스크롤에 사용할 수 있습니다.
+ *
+ * @param onIntersect
+ * @param options root, rootMargin, threshold
+ *
+ * @returns target 요소에 전달할 ref
+ */
+const useIntersection = (
+  onIntersect: (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void,
+  options?: IntersectionObserverInit
+) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  /**
+   * target 요소가 교차되었을 때 실행할 함수
+   *
+   * @param entries IntersectionObserverEntry 객체의 리스트
+   * @param observer 콜백함수가 호출되는 IntersectionObserver
+   */
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return ref;
+};
+
+export default useIntersection;


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#121

### 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

## 작업 상세 내용

경험카드 리스트에 사용하는 무한스크롤 기능을 구현하였습니다~

https://github.com/depromeet/InsightOut-client/assets/80238096/7c0ebc89-02f6-47af-8f38-dbf53c0b88de


### 1. useIntersection
   - 코드에 주석 자세히 달아놨는데 이해 안가는 부분 있으면 말해주세요!

### 2. 무한스크롤 페이지 적용 예시

``` tsx
const Test = () => {
  const { data, fetchNextPage, hasNextPage, isFetching } = useFetchTestData();

  // 각 page에서 응답받은 데이터를 일차원 배열에 저장
  const testData = useMemo(
    () => (data ? data.pages.flatMap(({ data }) => data) : []),
    [data]
  );

  // 뷰포트와 ref를 전달한 요소가 교차하면 콜백 호출
  const ref = useIntersect((entry, observer) => {
    observer.unobserve(entry.target);
    
    if (hasNextPage && !isFetching) fetchNextPage();
  });

  return (
    <>
      {testData.map((data) => (
        <>{data}</>
      ))}
      {/*  전체 리스트의 맨 아래가 viewport 내로 들어올 경우 fetch */}
      <div ref={ref}></div>
    </>
  );
};
```



- 참고 문서
  - https://tanstack.com/query/v4/docs/react/reference/useInfiniteQuery
  - https://tech.kakaoenterprise.com/149