### PR TITLE
refactor: 경험카드 만들기 페이지 prefetch

### DIFF
--- a/src/feature/analyze/complete/components/CompletePage.tsx
+++ b/src/feature/analyze/complete/components/CompletePage.tsx
@@ -16,7 +16,6 @@ import { useGetExperience } from '@/hooks/reactQuery/analyze/query';
 const CompletePage = () => {
   const [showLoading, setShowLoading] = useState(true);
   const [aiExperience, setAiExperience] = useState<AiResponse['submit']>();
-  // const { experienceId } = useExperienceId();
 
   const experienceId = Number(useSearchParams().get('experienceId')) ?? '0';
   const { mutateAsync: createAiExperienceCard, isLoading: isLoadingExperienceCard } = useSubmitExperience();
@@ -38,9 +37,6 @@ const CompletePage = () => {
       },
     }
   );
-
-  console.log(aiExperience);
-  console.log(experience);
 
   useEffect(() => {
     if (showLoading) {

--- a/src/features/analyze/verify/page.tsx
+++ b/src/features/analyze/verify/page.tsx
@@ -29,7 +29,7 @@ export const renderRecommendKeyword = (arr: CapabilitiesType[]) => {
 };
 
 const VerifyPage = () => {
-  const { back } = useRouter();
+  const { back, prefetch } = useRouter();
   const username = useUserNickname();
   const { getValues, setValue } = useFormContext<ExperienceFormValues>();
   const [situation, task, action, result, keywordList, experienceId, recommendKeywordList, resume, writeStatus] =
@@ -46,6 +46,10 @@ const VerifyPage = () => {
     ]);
 
   const { mutateAsync: createRecommendResume, isLoading: isRecommendResumeLoading } = useCreateRecommendResume();
+
+  useEffect(() => {
+    prefetch('/completed-experience-card');
+  }, [prefetch]);
 
   useEffect(() => {
     const isReadyToAIRecommendation = writeStatus?.slice(0, 3).every((status) => status === '작성완료');


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#

### 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 리팩토링
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 경험분해 > AI 직무역량 추천 페이지에서 경험카드 만들기 버튼을 누르면 페이지 요청을 하고 약 2.5초정도 후에 경험카드 완성페이지로 진입하고 있습니다. 
  - 이를 prefetch를 통해 경험카드 만들기 버튼을 누르기 전에 이미 페이지 요청을 끝내고 버튼을 누르면 바로 경험카드 완성페이지로 진입하도록 개선했습니다.
