### PR TITLE
fix: Aside 토글 수정 및 스크롤 추가

### DIFF
--- a/src/features/resume/components/Aside/Aside.tsx
+++ b/src/features/resume/components/Aside/Aside.tsx
@@ -27,7 +27,7 @@ const Aside = () => {
   };
 
   return (
-    <aside className="min-w-[363px] py-12 px-[30px]">
+    <aside className="min-w-[363px] py-12 px-[30px] overflow-y-scroll">
       <header className="flex items-center justify-between mb-7">
         <h1 className="flex gap-[6px] subhead1">
           <IconPencil />

--- a/src/features/resume/components/Aside/Aside.tsx
+++ b/src/features/resume/components/Aside/Aside.tsx
@@ -51,7 +51,7 @@ const Aside = () => {
           </Tooltip>
         )}
       </header>
-      <ResumeListContainer expandedResumeCount={resumeList?.length}>
+      <ResumeListContainer>
         {resumeList?.map((resume) => (
           <Resume key={resume.id} {...resume} />
         ))}

--- a/src/features/resume/components/Aside/Resume/ResumeListContainer.tsx
+++ b/src/features/resume/components/Aside/Resume/ResumeListContainer.tsx
@@ -4,20 +4,12 @@ import { Accordion } from '@chakra-ui/react';
 
 import { boxShadow } from '@/styles/theme/foundations/boxShadow';
 
-type ResumeListContainerProps = {
-  expandedResumeCount?: number;
-} & PropsWithChildren;
+type ResumeListContainerProps = PropsWithChildren;
 
-const ResumeListContainer = ({ expandedResumeCount, children }: ResumeListContainerProps) => {
-  /** @description 펼쳐진 상태의 아코디언의 인덱스
-   * - 기본적으로 모든 자기소개서 아코디언은 펼쳐져있습니다.
-   */
-  const expandedResumeIndexes = Array.from({ length: expandedResumeCount ?? 0 }).map((_, index) => index);
-
+const ResumeListContainer = ({ children }: ResumeListContainerProps) => {
   return (
     <Accordion
       allowMultiple
-      index={expandedResumeIndexes}
       display="flex"
       flexDirection="column"
       gap="8px"


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용

<img width="150" alt="image" src="https://github.com/depromeet/InsightOut-client/assets/80238096/78034db5-5e08-4aa0-bd0f-66170e2c8b45">

1. Aside 토글 수정
- #190 이슈로 인해 초기 렌더링 시 Aside가 접혀있는 상태로 렌더링 되도록 수정하였습니다.

2. Aside overflow시, y축 scroll 적용
- 자기소개서 개수가 늘어나서 넘칠 시, 세로 방향으로 스크롤 추가하였습니다.
