### PR TITLE
fix: 경험카드 완성 시, ai 데이터 누락 이슈 수정

### DIFF
--- a/src/feature/analyze/complete/components/CompletePage.tsx
+++ b/src/feature/analyze/complete/components/CompletePage.tsx
@@ -19,9 +19,10 @@ const CompletePage = () => {
   const [isShowConfetti, setIsShowConfetti] = useState(false);
 
   const experienceId = Number(useSearchParams().get('experienceId')) ?? '0';
-  const { mutateAsync: createAiExperienceCard, isLoading: isLoadingExperienceCard } = useSubmitExperience({
-    onSuccess: () => {
+  const { mutate: createAiExperienceCard, isLoading: isLoadingExperienceCard } = useSubmitExperience({
+    onSuccess: (data) => {
       setIsShowConfetti(true);
+      setAiExperience(data);
     },
   });
 
@@ -29,7 +30,7 @@ const CompletePage = () => {
     { experienceId },
     {
       enabled: !showLoading,
-      onSuccess: async (data) => {
+      onSuccess: (data) => {
         const payload = {
           experienceId,
           situation: data?.situation,
@@ -37,8 +38,7 @@ const CompletePage = () => {
           action: data?.action,
           result: data?.result,
         };
-        const _aiExpeience = await createAiExperienceCard(payload);
-        setAiExperience(_aiExpeience);
+        createAiExperienceCard(payload);
       },
     }
   );
@@ -68,8 +68,8 @@ const CompletePage = () => {
     experienceStatus: aiExperience?.experienceStatus!,
     experienceInfo: experience?.ExperienceInfo,
     star: star,
-    aiResume: experience?.AiResume?.content,
-    aiRecommendQuestions: experience?.AiRecommendQuestions,
+    aiResume: aiExperience?.AiResume?.content,
+    aiRecommendQuestions: aiExperience?.AiRecommendQuestion,
   };
 
   return (

--- a/src/features/collection/components/cards/ExperienceCard/ExperienceCard.tsx
+++ b/src/features/collection/components/cards/ExperienceCard/ExperienceCard.tsx
@@ -46,7 +46,6 @@ const ExperienceCard = ({
 }: Props) => {
   const username = useUserNickname();
 
-  console.log(username);
   const [isBack, setIsBack] = useState(false);
 
   const handleFlipClick = () => {
@@ -250,8 +249,8 @@ ExperienceCard.AIQuestions = ({ aiRecommendQuestions }: ExperienceCardAIQuestion
     <h6 className="h6 mb-[8px]">이 경험과 잘 맞는 자기소개서 문항</h6>
     {aiRecommendQuestions?.length ? (
       <ul className="flex flex-col gap-[8px]">
-        {aiRecommendQuestions?.map(({ id, createedAt, title }) => (
-          <li key={`${id}-${createedAt}`} className=" border-[1px] rounded-[8px] border-gray-300 py-[8px] px-[16px]">
+        {aiRecommendQuestions?.map(({ id, title }) => (
+          <li key={`${id}-${title}`} className=" border-[1px] rounded-[8px] border-gray-300 py-[8px] px-[16px]">
             <p className="w-full">{title}</p>
           </li>
         ))}

--- a/src/features/collection/types/index.ts
+++ b/src/features/collection/types/index.ts
@@ -30,8 +30,6 @@ export interface Experience {
 export type AiRecommendQuestions = {
   id: number;
   title: string;
-  createedAt: string;
-  updatedAt: string;
 };
 
 export type ExperienceInfo = {


### PR DESCRIPTION
### 이슈 번호

depromeet/13th-4team-client#

### 작업 분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

## 작업 상세 내용

### 수정사항 1: 경험카드 완성 시, ai 데이터 누락 이슈 수정

<img src="https://github.com/depromeet/InsightOut-client/assets/80238096/1858543f-eec4-4054-82a0-65227156a79d" width="500px" />

#### AS-IS
`experience`에서 AI 관련 데이터(AI 추천 자기소개서, AI 자기소개서 문항)를 가져옴

#### TO-BE
- `aiExperience`에서 가져오도록 수정
- 경험카드 GET -> GET 응답(experience)으로 받은 STAR로 AI 관련 내용 POST -> POST 응답 값(aiExperience)으로 완성된 경험카드 보여줌 

---

### 수정사항 2: AiRecommendQuestions 필드 삭제
- 서버 응답 값에 createdAt, updatedAt 없어서 삭제했습니다